### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check Dockerfile compliance
-        run: docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+        run: docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 
   build-docker:
     runs-on: ubuntu-20.04
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build -t reanahub/reana-auth-rucio .
+        run: docker build -t docker.io/reanahub/reana-auth-rucio .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASETAG=release-1.30.0
-FROM rucio/rucio-clients:$BASETAG
+FROM docker.io/rucio/rucio-clients:$BASETAG
 
 USER root
 
@@ -8,8 +8,7 @@ COPY ./linuxsupport7s-stable.repo /etc/yum.repos.d/
 # Add the rucio configuration template
 COPY --chown=user:user files/rucio.cfg.j2 /opt/user/rucio.cfg.j2
 
-# EGI trust anchors
-
+# Add CA certificates
 RUN yum -y install ca-certificates ca-policy-egi-core && \
     yum install -y CERN-CA-certs && \
     yum clean all && \


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.