### PR TITLE
update rucio config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-ARG BASETAG=release-1.29.1
+ARG BASETAG=release-1.30.0
 FROM rucio/rucio-clients:$BASETAG
 
 USER root
 
-# CERN certificate
-COPY --chown=user:user files/CERN-bundle.pem /etc/pki/tls/certs/CERN-bundle.pem
+COPY ./linuxsupport7s-stable.repo /etc/yum.repos.d/
 
 # Add the rucio configuration template
 COPY --chown=user:user files/rucio.cfg.j2 /opt/user/rucio.cfg.j2
 
 # EGI trust anchors
-RUN curl -Lo /etc/yum.repos.d/EGI-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo && \
-    yum -y install ca-certificates ca-policy-egi-core && \
+
+RUN yum -y install ca-certificates ca-policy-egi-core && \
+    yum install -y CERN-CA-certs && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/files/rucio.cfg.j2
+++ b/files/rucio.cfg.j2
@@ -1,7 +1,7 @@
 [client]
 rucio_host = {{ RUCIO_CFG_RUCIO_HOST | default('') }}
 auth_host = {{ RUCIO_CFG_AUTH_HOST | default('') }}
-ca_cert = {{ RUCIO_CFG_CA_CERT | default('/rucio_cache/CERN-bundle.pem') }}
+ca_cert = {{ RUCIO_CFG_CA_CERT | default('/etc/pki/tls/certs/CERN-bundle.pem') }}
 auth_type = {{ RUCIO_CFG_AUTH_TYPE | default('x509_proxy') }}
 username = {{ RUCIO_CFG_USERNAME | default('') }}
 password = {{ RUCIO_CFG_PASSWORD | default('') }}

--- a/linuxsupport7s-stable.repo
+++ b/linuxsupport7s-stable.repo
@@ -1,0 +1,9 @@
+# Example modified for cc7 taken from https://gitlab.cern.ch/linuxsupport/rpmci/-/blob/master/kojicli/linuxsupport8s-stable.repo 
+[linuxsupport7s-stable]
+name=linuxsupport [stable]
+baseurl=https://linuxsoft.cern.ch/cern/centos/7/cern/$basearch
+enabled=1
+gpgcheck=False
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-koji file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kojiv2
+priority=1
+protect=1


### PR DESCRIPTION
automated way to get CA certs for CERN-bundle, updating rucio clients to 1.30, adding default connection to VRE instance