### PR TITLE
docker: add more WLCG site certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,18 @@ USER root
 
 COPY ./linuxsupport7s-stable.repo /etc/yum.repos.d/
 
-# Add the rucio configuration template
+# Add Rucio client configuration template
 COPY --chown=user:user files/rucio.cfg.j2 /opt/user/rucio.cfg.j2
 
-# Add CA certificates
-RUN yum -y install ca-certificates ca-policy-egi-core && \
-    yum install -y CERN-CA-certs && \
-    yum clean all && \
+# Add EGI CA certificates
+COPY ./EGI-trustanchors.repo /etc/yum.repos.d/
+
+# Install certificates
+RUN yum -y install \
+        CERN-CA-certs \
+        ca-certificates \
+        ca-policy-egi-core && \
+    yum -y clean all && \
     rm -rf /var/cache/yum
 
 USER user

--- a/EGI-trustanchors.repo
+++ b/EGI-trustanchors.repo
@@ -1,0 +1,6 @@
+[EGI-trustanchors]
+name=EGI-trustanchors
+baseurl=https://repository.egi.eu/sw/production/cas/1/current/
+enabled=1
+gpgcheck=1
+gpgkey=https://repository.egi.eu/sw/production/cas/1/GPG-KEY-EUGridPMA-RPM-3

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ additional files present in this repository:
 Changes
 =======
 
-Version 1.1.1 (UNRELEASED)
+Version 1.1.1 (2023-09-11)
 --------------------------
 
 - Adds more WLCG certificates to facilitate data access to outside-CERN sites.

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Inside the container Rucio commands can be executed, for example via:
   $ rucio whoami
 
 Dependencies
-=============
+============
 
 Building the container and successfully obtaining Rucio configuration requires
 additional files present in this repository:
@@ -57,6 +57,11 @@ additional files present in this repository:
 
 Changes
 =======
+
+Version 1.1.1 (UNRELEASED)
+--------------------------
+
+- Adds more WLCG certificates to facilitate data access to outside-CERN sites.
 
 Version 1.1.0 (2023-08-22)
 --------------------------


### PR DESCRIPTION
Adds more WLCG certificates for non-CERN sites, solving observed issues with Rucio client accessing data located on non-CERN sites.