### PR TITLE
build(docker): upgrade to Alma 9 and Rucio 35.2 (#17)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG BASETAG=release-1.30.0
+ARG BASETAG=release-35.2.0
 FROM docker.io/rucio/rucio-clients:$BASETAG
 
 USER root
 
-COPY ./linuxsupport7s-stable.repo /etc/yum.repos.d/
+COPY ./linuxsoft-alma9.repo /etc/yum.repos.d/
 
 # Add Rucio client configuration template
 COPY --chown=user:user files/rucio.cfg.j2 /opt/user/rucio.cfg.j2

--- a/linuxsoft-alma9.repo
+++ b/linuxsoft-alma9.repo
@@ -1,0 +1,8 @@
+[linuxsoft-alma9]
+name=AlmaLinux 9 - CERN
+baseurl=http://linuxsoft.cern.ch/cern/alma/9/CERN/$basearch
+enabled=1
+gpgcheck=False
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-koji file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kojiv2
+priority=1
+protect=1

--- a/linuxsupport7s-stable.repo
+++ b/linuxsupport7s-stable.repo
@@ -1,9 +1,0 @@
-# Example modified for cc7 taken from https://gitlab.cern.ch/linuxsupport/rpmci/-/blob/master/kojicli/linuxsupport8s-stable.repo 
-[linuxsupport7s-stable]
-name=linuxsupport [stable]
-baseurl=https://linuxsoft.cern.ch/cern/centos/7/cern/$basearch
-enabled=1
-gpgcheck=False
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-koji file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kojiv2
-priority=1
-protect=1


### PR DESCRIPTION
- Change the basetag from `release-1.30.0` to `release-35.2.0`.
- Update software repository.